### PR TITLE
Add VTK polyhedron support

### DIFF
--- a/barney/include/barney.h
+++ b/barney/include/barney.h
@@ -183,7 +183,8 @@ typedef enum {
   BN_UNSTRUCTURED_TET = 10,
   BN_UNSTRUCTURED_HEX = 12,
   BN_UNSTRUCTURED_PRISM = 13,
-  BN_UNSTRUCTURED_PYRAMID = 14
+  BN_UNSTRUCTURED_PYRAMID = 14,
+  BN_UNSTRUCTURED_POLYHEDRON = 42
 } BNUnstructuredElementType;
 
 /*! currently supported texture filter modes */

--- a/barney/umesh/common/UMeshField.cu
+++ b/barney/umesh/common/UMeshField.cu
@@ -125,17 +125,35 @@ namespace BARNEY_NS {
 
     auto cellType = mesh.cellTypes[cellIdx];
     if (cellType == _VTK_TET || cellType == _ANARI_TET) {
-      uint32_t ofs0 = mesh.cellOffsets[cellIdx];
-      const vec4i indices = *(const vec4i *)&mesh.indices[ofs0];
-      int sidx_x = mesh.scalarsArePerVertex ? indices.x : cellIdx;
-      int sidx_y = mesh.scalarsArePerVertex ? indices.y : cellIdx;
-      int sidx_z = mesh.scalarsArePerVertex ? indices.z : cellIdx;
-      int sidx_w = mesh.scalarsArePerVertex ? indices.w : cellIdx;
-      vec4f a(mesh.vertices[indices.x],mesh.scalars[sidx_x]);
-      vec4f b(mesh.vertices[indices.y],mesh.scalars[sidx_y]);
-      vec4f c(mesh.vertices[indices.z],mesh.scalars[sidx_z]);
-      vec4f d(mesh.vertices[indices.w],mesh.scalars[sidx_w]);
-      rasterTet<5>(grid,a,b,c,d);
+      const int ofs0 = mesh.cellOffsets[cellIdx];
+      if (ofs0 < 0
+          || (long long)ofs0 + 4 > (long long)mesh.numIndices)
+        return;
+      const int *ix = mesh.indices + ofs0;
+      const vec4i id(ix[0], ix[1], ix[2], ix[3]);
+      auto vtxOk = [&](int vi) {
+        return vi >= 0 && vi < mesh.numVertices;
+      };
+      if (!vtxOk(id.x) || !vtxOk(id.y) || !vtxOk(id.z) || !vtxOk(id.w))
+        return;
+      int sidx_x = mesh.scalarsArePerVertex ? id.x : cellIdx;
+      int sidx_y = mesh.scalarsArePerVertex ? id.y : cellIdx;
+      int sidx_z = mesh.scalarsArePerVertex ? id.z : cellIdx;
+      int sidx_w = mesh.scalarsArePerVertex ? id.w : cellIdx;
+      if (mesh.scalarsArePerVertex) {
+        if (sidx_x < 0 || sidx_x >= mesh.numScalars
+            || sidx_y < 0 || sidx_y >= mesh.numScalars
+            || sidx_z < 0 || sidx_z >= mesh.numScalars
+            || sidx_w < 0 || sidx_w >= mesh.numScalars)
+          return;
+      } else if (cellIdx < 0 || cellIdx >= mesh.numScalars) {
+        return;
+      }
+      vec4f a(mesh.vertices[id.x], mesh.scalars[sidx_x]);
+      vec4f b(mesh.vertices[id.y], mesh.scalars[sidx_y]);
+      vec4f c(mesh.vertices[id.z], mesh.scalars[sidx_z]);
+      vec4f d(mesh.vertices[id.w], mesh.scalars[sidx_w]);
+      rasterTet<5>(grid, a, b, c, d);
     } else {
       const box4f eltBounds = mesh.cellBounds(cellIdx);
       rasterBox(grid,getBox(mesh.worldBounds),eltBounds);
@@ -218,6 +236,53 @@ namespace BARNEY_NS {
 
     return false;
   }
+
+#if RTC_DEVICE_CODE
+  /*! cuBQL BVH build (refit_init) assumes finite, non-inverted prim boxes.
+      Invalid connectivity (e.g. OOB vertex indices) yields empty / ±inf
+      bounds from cellBounds — sanitize to a tiny finite box so the builder
+      does not corrupt GPU memory; sampling still rejects bad cells in
+      eltScalar / tetScalar. */
+  inline __rtc_device bool umeshFiniteF(float x)
+  {
+    return (x == x) && (fabsf(x) < 1e37f);
+  }
+
+  inline __rtc_device bool umeshPrimBoundsSafeForCuBQL(const box4f &eb)
+  {
+    const box3f pb = getBox(eb);
+    const range1f rw = getRange(eb);
+    if (pb.empty())
+      return false;
+    if (!umeshFiniteF(pb.lower.x) || !umeshFiniteF(pb.lower.y)
+        || !umeshFiniteF(pb.lower.z) || !umeshFiniteF(pb.upper.x)
+        || !umeshFiniteF(pb.upper.y) || !umeshFiniteF(pb.upper.z))
+      return false;
+    if (!umeshFiniteF(rw.lower) || !umeshFiniteF(rw.upper))
+      return false;
+    if (rw.lower > rw.upper)
+      return false;
+    return true;
+  }
+
+  inline __rtc_device box4f umeshSanitizePrimBoundsForCuBQL(const UMeshField::DD &mesh,
+                                                              const box4f &eb)
+  {
+    if (umeshPrimBoundsSafeForCuBQL(eb))
+      return eb;
+    const box3f &wb = mesh.worldBounds;
+    if (!wb.empty() && umeshFiniteF(wb.lower.x) && umeshFiniteF(wb.lower.y)
+        && umeshFiniteF(wb.lower.z) && umeshFiniteF(wb.upper.x)
+        && umeshFiniteF(wb.upper.y) && umeshFiniteF(wb.upper.z)) {
+      const vec3f mid = 0.5f * (wb.lower + wb.upper);
+      const float pad = 1e-3f;
+      const vec3f lo(mid.x - pad, mid.y - pad, mid.z - pad);
+      const vec3f hi(mid.x + pad, mid.y + pad, mid.z + pad);
+      return box4f(vec4f(lo, 0.f), vec4f(hi, 1.f));
+    }
+    return box4f(vec4f(0.f, 0.f, 0.f, 0.f), vec4f(1.f, 1.f, 1.f, 1.f));
+  }
+#endif
     
   __rtc_global 
   void umeshComputeElementBBs(rtc::ComputeInterface ci,
@@ -225,12 +290,14 @@ namespace BARNEY_NS {
                               box3f   *d_primBounds,
                               range1f *d_primRanges)
   {
+#if RTC_DEVICE_CODE
     const int tid = ci.launchIndex().x;
     if (tid >= mesh.numCells) return;
     
-    box4f eb = mesh.cellBounds(tid);
+    const box4f eb = umeshSanitizePrimBoundsForCuBQL(mesh, mesh.cellBounds(tid));
     d_primBounds[tid] = getBox(eb);
     if (d_primRanges) d_primRanges[tid] = getRange(eb);
+#endif
   }
   
   /*! computes, on specified device, the bounding boxes and - if
@@ -331,6 +398,9 @@ namespace BARNEY_NS {
     dd.cellTypes   = (const uint8_t *)cellTypes->getDD(device);
     dd.scalarsArePerVertex = scalarsArePerVertex;
     dd.numCells    = (int)cellOffsets->count;
+    dd.numVertices = (int)vertices->count;
+    dd.numScalars  = (int)scalars->count;
+    dd.numIndices  = (int)indices->count;
     assert(dd.numCells > 0);
     assert(dd.vertices);
     assert(dd.indices);
@@ -360,5 +430,4 @@ namespace BARNEY_NS {
 #endif
   }
 }
-
 

--- a/barney/umesh/common/UMeshField.h
+++ b/barney/umesh/common/UMeshField.h
@@ -22,7 +22,8 @@ namespace BARNEY_NS {
     _VTK_TET = 10,
     _VTK_HEX = 12,
     _VTK_PRISM = 13,
-    _VTK_PYR = 14
+    _VTK_PYR = 14,
+    _VTK_POLYHEDRON = 42
   };
 
   /*! scalar field represented by a unstructured mesh. can contain
@@ -90,12 +91,25 @@ namespace BARNEY_NS {
                      vec3f P, bool
                      dbg=false) const;
 
+      /* compute scalar of given polyhedron in umesh, at point P, and
+         return that in 'retVal'. returns true if P is inside the
+         element, false if outside (in which case retVal is not
+         defined). Containment uses +X ray parity over face fans (convex /
+         well-behaved cells; see `umesh_poly_stream`). Per-vertex scalars use
+         inverse-distance weights over face-stream corners. */
+      inline __rtc_device bool polyScalar(float &retVal,
+                                          uint32_t cellIdx,
+                                          vec3f P) const;
+
       const vec3f       *vertices;
       const float       *scalars;
       const int         *indices;
       const int         *cellOffsets;
       const uint8_t     *cellTypes;
       int                numCells;
+      int                numVertices;
+      int                numScalars;
+      int                numIndices;
       bool               scalarsArePerVertex;
     };
 
@@ -150,7 +164,103 @@ namespace BARNEY_NS {
     PLD *getPLD(Device *device);
     std::vector<PLD> perLogical;
   };
-  
+
+  /*! VTK_POLYHEDRON face stream: numFaces, then per face (n, i0..i_{n-1}).
+      All index reads stay within numIndices; faces/points capped; each
+      vertex index is validated before any vertices[]/scalars[] load.
+
+      Containment (`polyScalar`) uses +X ray parity over triangle fans; that
+      matches convex, consistently oriented polyhedra (typical CFD meshes).
+      Non-convex cells can classify inside/outside incorrectly. */
+  namespace umesh_poly_stream {
+    static constexpr int kMaxFaces = 8192;
+    static constexpr int kMaxPtsPerFace = 1024;
+
+    struct FaceStreamReader {
+      const int *indices;
+      int numIndices;
+      int numVertices;
+      int numScalars;
+      bool scalarsArePerVertex;
+      uint32_t cellIdx;
+      int pos;
+      int numFaces;
+      bool ok;
+
+      inline __rtc_device FaceStreamReader(const int *indices_,
+                                           int numIndices_,
+                                           int numVertices_,
+                                           int numScalars_,
+                                           bool scalarsArePerVertex_,
+                                           uint32_t cellIdx_,
+                                           int offset)
+          : indices(indices_),
+            numIndices(numIndices_),
+            numVertices(numVertices_),
+            numScalars(numScalars_),
+            scalarsArePerVertex(scalarsArePerVertex_),
+            cellIdx(cellIdx_),
+            pos(0),
+            numFaces(0),
+            ok(false)
+      {
+        if (offset < 0 || offset >= numIndices)
+          return;
+        pos = offset;
+        if (pos + 1 > numIndices)
+          return;
+        numFaces = indices[pos++];
+        if (numFaces <= 0 || numFaces > kMaxFaces)
+          return;
+        if (!scalarsArePerVertex) {
+          const int sci = (int)cellIdx;
+          if (sci < 0 || sci >= numScalars)
+            return;
+        }
+        ok = true;
+      }
+
+      inline __rtc_device bool faceBegin(int &numPts)
+      {
+        if (!ok)
+          return false;
+        if (pos + 1 > numIndices) {
+          ok = false;
+          return false;
+        }
+        numPts = indices[pos++];
+        if (numPts < 3 || numPts > kMaxPtsPerFace) {
+          ok = false;
+          return false;
+        }
+        if (pos + numPts > numIndices) {
+          ok = false;
+          return false;
+        }
+        return true;
+      }
+
+      inline __rtc_device bool readVertex(int &vtxIdx, int &scalarIdx)
+      {
+        if (!ok || pos >= numIndices) {
+          ok = false;
+          return false;
+        }
+        vtxIdx = indices[pos++];
+        if (vtxIdx < 0 || vtxIdx >= numVertices) {
+          ok = false;
+          return false;
+        }
+        scalarIdx = scalarsArePerVertex ? vtxIdx : (int)cellIdx;
+        if (scalarsArePerVertex && (scalarIdx < 0 || scalarIdx >= numScalars)) {
+          ok = false;
+          return false;
+        }
+        return true;
+      }
+    };
+  } // namespace umesh_poly_stream
+
   // ==================================================================
   // IMPLEMENTATION
   // ==================================================================
@@ -159,33 +269,74 @@ namespace BARNEY_NS {
   box4f UMeshField::DD::cellBounds(uint32_t cellIdx) const
   {
     uint32_t cellType = cellTypes[cellIdx];
-    uint32_t numVertices = 0;
-    uint32_t offset = cellOffsets[cellIdx];
+    int offset = cellOffsets[cellIdx];
+
+    if (cellType == _VTK_POLYHEDRON) {
+      umesh_poly_stream::FaceStreamReader stream(
+          indices,
+          numIndices,
+          numVertices,
+          numScalars,
+          scalarsArePerVertex,
+          cellIdx,
+          offset);
+      if (!stream.ok)
+        return box4f{};
+      box4f bb;
+      for (int f = 0; f < stream.numFaces; f++) {
+        int numPts = 0;
+        if (!stream.faceBegin(numPts))
+          return box4f{};
+        for (int p = 0; p < numPts; p++) {
+          int vtxIdx = 0, si = 0;
+          if (!stream.readVertex(vtxIdx, si))
+            return box4f{};
+          bb.extend(vec4f(vertices[vtxIdx], scalars[si]));
+        }
+      }
+      return bb;
+    }
+
+    uint32_t nv = 0;
     switch (cellType) {
     case _VTK_TET:
     case _ANARI_TET:
-      numVertices = 4;
+      nv = 4;
       break;
     case _VTK_PYR:
     case _ANARI_PYR:
-      numVertices = 5;
+      nv = 5;
       break;
     case _VTK_PRISM:
     case _ANARI_PRISM:
-      numVertices = 6;
+      nv = 6;
       break;
-    case _VTK_HEX: 
-    case _ANARI_HEX: 
-      numVertices = 8;
+    case _VTK_HEX:
+    case _ANARI_HEX:
+      nv = 8;
       break;
     default:
       ;
     }
 
     box4f bb;
-    for (uint32_t i=0;i<numVertices;i++) {
+    if (nv == 0)
+      return bb;
+    if (offset < 0
+        || (long long)offset + (long long)nv > (long long)numIndices)
+      return bb;
+    const int sci = scalarsArePerVertex ? 0 : (int)cellIdx;
+    if (!scalarsArePerVertex && (sci < 0 || sci >= numScalars))
+      return bb;
+
+    for (uint32_t i = 0; i < nv; i++) {
       int vtxIdx = indices[offset++];
-      vec4f v(vertices[vtxIdx],scalars[scalarsArePerVertex?vtxIdx:cellIdx]);
+      if (vtxIdx < 0 || vtxIdx >= numVertices)
+        return box4f{};
+      const int si = scalarsArePerVertex ? vtxIdx : sci;
+      if (scalarsArePerVertex && (si < 0 || si >= numScalars))
+        return box4f{};
+      vec4f v(vertices[vtxIdx], scalars[si]);
       bb.extend(v);
     }
     return bb;
@@ -217,8 +368,8 @@ namespace BARNEY_NS {
   {
     uint8_t cellType = cellTypes[cellIdx];
     switch (cellType) {
-    case _ANARI_TET: 
-    case _VTK_TET: 
+    case _ANARI_TET:
+    case _VTK_TET:
       return tetScalar(retVal,cellIdx,P,dbg);
     case _ANARI_PYR:
     case _VTK_PYR:
@@ -229,6 +380,8 @@ namespace BARNEY_NS {
     case _ANARI_HEX:
     case _VTK_HEX:
       return hexScalar(retVal,cellIdx,P,dbg);
+    case _VTK_POLYHEDRON:
+      return polyScalar(retVal,cellIdx,P);
     }
     return false;
   }
@@ -240,8 +393,23 @@ namespace BARNEY_NS {
                                  bool dbg) const
   {
     int ofs0 = cellOffsets[cellIdx];
-    vec4i indices = *(const vec4i *)&this->indices[ofs0];
-    
+    if (ofs0 < 0 || (long long)ofs0 + 4 > (long long)numIndices)
+      return false;
+    const int *ix = this->indices + ofs0;
+    vec4i indices(ix[0], ix[1], ix[2], ix[3]);
+    auto badVtx = [&](int v) { return v < 0 || v >= numVertices; };
+    if (badVtx(indices.x) || badVtx(indices.y) || badVtx(indices.z)
+        || badVtx(indices.w))
+      return false;
+    if (scalarsArePerVertex) {
+      auto badS = [&](int s) { return s < 0 || s >= numScalars; };
+      if (badS(indices.x) || badS(indices.y) || badS(indices.z)
+          || badS(indices.w))
+        return false;
+    } else if ((int)cellIdx >= numScalars) {
+      return false;
+    }
+
     vec4f v0(vertices[indices.x],scalars[scalarsArePerVertex?indices.x:cellIdx]);
     vec4f v1(vertices[indices.y],scalars[scalarsArePerVertex?indices.y:cellIdx]);
     vec4f v2(vertices[indices.z],scalars[scalarsArePerVertex?indices.z:cellIdx]);
@@ -271,7 +439,18 @@ namespace BARNEY_NS {
                                  vec3f P) const
   {
     int ofs0 = cellOffsets[cellIdx];
-    UMeshField::ints<5> indices = *(const UMeshField::ints<5> *)&this->indices[ofs0];
+    if (ofs0 < 0 || (long long)ofs0 + 5 > (long long)numIndices)
+      return false;
+    UMeshField::ints<5> indices;
+    const int *src = this->indices + ofs0;
+    for (int k = 0; k < 5; k++)
+      indices[k] = src[k];
+    for (int k = 0; k < 5; k++) {
+      int v = indices[k];
+      if (v < 0 || v >= numVertices) return false;
+      if (scalarsArePerVertex && (v < 0 || v >= numScalars)) return false;
+    }
+    if (!scalarsArePerVertex && (int)cellIdx >= numScalars) return false;
     vec4f v0(vertices[indices[0]],scalars[scalarsArePerVertex?indices[0]:cellIdx]);
     vec4f v1(vertices[indices[1]],scalars[scalarsArePerVertex?indices[1]:cellIdx]);
     vec4f v2(vertices[indices[2]],scalars[scalarsArePerVertex?indices[2]:cellIdx]);
@@ -286,8 +465,18 @@ namespace BARNEY_NS {
                                  vec3f P) const
   {
     int ofs0 = cellOffsets[cellIdx];
-    UMeshField::ints<6> indices
-      = *(const UMeshField::ints<6> *)&this->indices[ofs0];
+    if (ofs0 < 0 || (long long)ofs0 + 6 > (long long)numIndices)
+      return false;
+    UMeshField::ints<6> indices;
+    const int *src = this->indices + ofs0;
+    for (int k = 0; k < 6; k++)
+      indices[k] = src[k];
+    for (int k = 0; k < 6; k++) {
+      int v = indices[k];
+      if (v < 0 || v >= numVertices) return false;
+      if (scalarsArePerVertex && (v < 0 || v >= numScalars)) return false;
+    }
+    if (!scalarsArePerVertex && (int)cellIdx >= numScalars) return false;
     vec4f v0(vertices[indices[0]],scalars[scalarsArePerVertex?indices[0]:cellIdx]);
     vec4f v1(vertices[indices[1]],scalars[scalarsArePerVertex?indices[1]:cellIdx]);
     vec4f v2(vertices[indices[2]],scalars[scalarsArePerVertex?indices[2]:cellIdx]);
@@ -304,8 +493,18 @@ namespace BARNEY_NS {
                                  bool dbg) const
   {
     int ofs0 = cellOffsets[cellIdx];
-    UMeshField::ints<8> indices
-      = *(const UMeshField::ints<8> *)&this->indices[ofs0];
+    if (ofs0 < 0 || (long long)ofs0 + 8 > (long long)numIndices)
+      return false;
+    UMeshField::ints<8> indices;
+    const int *src = this->indices + ofs0;
+    for (int k = 0; k < 8; k++)
+      indices[k] = src[k];
+    for (int k = 0; k < 8; k++) {
+      int v = indices[k];
+      if (v < 0 || v >= numVertices) return false;
+      if (scalarsArePerVertex && (v < 0 || v >= numScalars)) return false;
+    }
+    if (!scalarsArePerVertex && (int)cellIdx >= numScalars) return false;
     vec4f v0(vertices[indices[0]],scalars[scalarsArePerVertex?indices[0]:cellIdx]);
     vec4f v1(vertices[indices[1]],scalars[scalarsArePerVertex?indices[1]:cellIdx]);
     vec4f v2(vertices[indices[2]],scalars[scalarsArePerVertex?indices[2]:cellIdx]);
@@ -316,5 +515,114 @@ namespace BARNEY_NS {
     vec4f v7(vertices[indices[7]],scalars[scalarsArePerVertex?indices[7]:cellIdx]);
     return intersectHexEXT(retVal, P, v0,v1,v2,v3,v4,v5,v6,v7, dbg);
   }
-  
+
+  inline __rtc_device
+  bool UMeshField::DD::polyScalar(float &retVal,
+                                  uint32_t cellIdx,
+                                  vec3f P) const
+  {
+    const int offset = cellOffsets[cellIdx];
+    umesh_poly_stream::FaceStreamReader stream(indices,
+                                               numIndices,
+                                               numVertices,
+                                               numScalars,
+                                               scalarsArePerVertex,
+                                               cellIdx,
+                                               offset);
+    if (!stream.ok)
+      return false;
+
+    // ---- point-in-polyhedron via ray casting along +X ----
+    int crossings = 0;
+    for (int f = 0; f < stream.numFaces; f++) {
+      int numPts = 0;
+      if (!stream.faceBegin(numPts))
+        return false;
+      int v0Idx = 0, si0 = 0;
+      if (!stream.readVertex(v0Idx, si0))
+        return false;
+      (void)si0;
+      int v1Idx = 0, si1 = 0;
+      if (!stream.readVertex(v1Idx, si1))
+        return false;
+      (void)si1;
+      vec3f a = vertices[v0Idx];
+      for (int t = 0; t < numPts - 2; t++) {
+        int v2Idx = 0, si2 = 0;
+        if (!stream.readVertex(v2Idx, si2))
+          return false;
+        (void)si2;
+        vec3f b = vertices[v1Idx];
+        vec3f c = vertices[v2Idx];
+        // Moller-Trumbore ray-triangle intersection (ray: P + t*(1,0,0))
+        vec3f e1 = b - a;
+        vec3f e2 = c - a;
+        // d x e2, where d = (1,0,0)
+        vec3f h = vec3f(0.f, -e2.z, e2.y);
+        float det = dot(e1, h);
+        if (fabsf(det) < 1e-12f) {
+          v1Idx = v2Idx;
+          continue;
+        }
+        float inv_det = 1.f / det;
+        vec3f s = P - a;
+        float u = inv_det * dot(s, h);
+        if (u < 0.f || u > 1.f) {
+          v1Idx = v2Idx;
+          continue;
+        }
+        vec3f q = cross(s, e1);
+        float v = inv_det * q.x; // dot((1,0,0), q)
+        if (v < 0.f || u + v > 1.f) {
+          v1Idx = v2Idx;
+          continue;
+        }
+        float ray_t = inv_det * dot(e2, q);
+        if (ray_t > 0.f)
+          crossings++;
+        v1Idx = v2Idx;
+      }
+    }
+
+    if ((crossings & 1) == 0)
+      return false;
+
+    // ---- scalar evaluation ----
+    if (!scalarsArePerVertex) {
+      retVal = scalars[cellIdx];
+      return true;
+    }
+
+    umesh_poly_stream::FaceStreamReader idwStream(indices,
+                                                numIndices,
+                                                numVertices,
+                                                numScalars,
+                                                scalarsArePerVertex,
+                                                cellIdx,
+                                                offset);
+    if (!idwStream.ok)
+      return false;
+    float weightSum = 0.f;
+    float valueSum = 0.f;
+    for (int f = 0; f < idwStream.numFaces; f++) {
+      int numPts = 0;
+      if (!idwStream.faceBegin(numPts))
+        return false;
+      for (int p = 0; p < numPts; p++) {
+        int vtxIdx = 0, si = 0;
+        if (!idwStream.readVertex(vtxIdx, si))
+          return false;
+        vec3f vp = vertices[vtxIdx];
+        float dist2 = dot(vp - P, vp - P);
+        float w = 1.f / fmaxf(dist2, 1e-20f);
+        weightSum += w;
+        valueSum += w * scalars[si];
+      }
+    }
+    if (weightSum <= 0.f)
+      return false;
+    retVal = valueSum / weightSum;
+    return true;
+  }
+
 }

--- a/barney/umesh/os/AWT.dev.cu
+++ b/barney/umesh/os/AWT.dev.cu
@@ -169,7 +169,18 @@ namespace BARNEY_NS {
     cubic.tRange = initRange;
     
     // printf("tet ofs0 %i\n",elt.ofs0);
-    vec4i tet = *(const vec4i *)&mesh.indices[elt.ofs0];
+    if (elt.ofs0 < 0
+        || (long long)elt.ofs0 + 4 > (long long)mesh.numIndices) {
+      cubic.tRange = { +BARNEY_INF, -BARNEY_INF };
+      return cubic;
+    }
+    const int *ix = mesh.indices + elt.ofs0;
+    vec4i tet(ix[0], ix[1], ix[2], ix[3]);
+    if (tet.x < 0 || tet.x >= mesh.numVertices || tet.y < 0 || tet.y >= mesh.numVertices
+        || tet.z < 0 || tet.z >= mesh.numVertices || tet.w < 0 || tet.w >= mesh.numVertices) {
+      cubic.tRange = { +BARNEY_INF, -BARNEY_INF };
+      return cubic;
+    }
     // printf("tet ofs0 %i -> %i %i %i %i\n",elt.ofs0,
     //        tet.x,tet.y,tet.z,tet.w);
     vec4f v0 = rtc::load(((rtc::float4*)mesh.vertices)[tet.x]);

--- a/barney/umesh/os/ObjectSpace-common.h
+++ b/barney/umesh/os/ObjectSpace-common.h
@@ -39,6 +39,14 @@ namespace barney {
       
     UMeshField *const mesh;
   };
+
+  /*! Connectivity and vertex pointers for object-space kernels live in
+      `volume.sfSampler` (UMeshCuBQLSampler::DD / UMeshField::DD). */
+  inline __both__ const BARNEY_NS::UMeshField::DD &
+  umeshOf(const UMeshObjectSpace::DD &dd)
+  {
+    return dd.volume.sfSampler;
+  }
   
   /*! the main function provided by this header file - intersecting a
     ray against a given leaf node in a object-space umesh bvh */
@@ -441,11 +449,21 @@ namespace barney {
   {
     if (elt.type != Element::TET) return false;
 
-    vec4i indices = (const vec4i &)dd.indices[elt.ofs0];
-    set(dd.vertices[indices.x],
-        dd.vertices[indices.y],
-        dd.vertices[indices.z],
-        dd.vertices[indices.w]);
+    const BARNEY_NS::UMeshField::DD &mesh = umeshOf(dd);
+    int ofs0 = elt.ofs0;
+    if (ofs0 < 0 || (long long)ofs0 + 4 > (long long)mesh.numIndices)
+      return false;
+    const int *ix = mesh.indices + ofs0;
+    vec4i indices(ix[0], ix[1], ix[2], ix[3]);
+    auto badVtx = [&](int v) { return v < 0 || v >= mesh.numVertices; };
+    if (badVtx(indices.x) || badVtx(indices.y) || badVtx(indices.z)
+        || badVtx(indices.w))
+      return false;
+
+    set(mesh.vertices[indices.x],
+        mesh.vertices[indices.y],
+        mesh.vertices[indices.z],
+        mesh.vertices[indices.w]);
 
     return true;
   }
@@ -497,45 +515,84 @@ namespace barney {
   bool ElementIntersector::setElement(Element elt)
   {
     element = elt;
+    const BARNEY_NS::UMeshField::DD &mesh = umeshOf(dd);
     switch (elt.type)
       {
       case Element::TET: {
-        vec4i indices = (const vec4i&)dd.indices[elt.ofs0];
-        v0 = dd.vertices[indices.x];
-        v1 = dd.vertices[indices.y];
-        v2 = dd.vertices[indices.z];
-        v3 = dd.vertices[indices.w];
+        int ofs0 = elt.ofs0;
+        if (ofs0 < 0 || (long long)ofs0 + 4 > (long long)mesh.numIndices)
+          return false;
+        const int *ix = mesh.indices + ofs0;
+        vec4i indices(ix[0], ix[1], ix[2], ix[3]);
+        auto badVtx = [&](int v) { return v < 0 || v >= mesh.numVertices; };
+        if (badVtx(indices.x) || badVtx(indices.y) || badVtx(indices.z)
+            || badVtx(indices.w))
+          return false;
+        v0 = mesh.vertices[indices.x];
+        v1 = mesh.vertices[indices.y];
+        v2 = mesh.vertices[indices.z];
+        v3 = mesh.vertices[indices.w];
       }
         break;
       case Element::PYR: {
-        ints5 indices = (const ints5&)dd.indices[elt.ofs0];
-        v0 = dd.vertices[indices[0]];
-        v1 = dd.vertices[indices[1]];
-        v2 = dd.vertices[indices[2]];
-        v3 = dd.vertices[indices[3]];
-        v4 = dd.vertices[indices[4]];
+        int ofs0 = elt.ofs0;
+        if (ofs0 < 0 || (long long)ofs0 + 5 > (long long)mesh.numIndices)
+          return false;
+        ints5 indices;
+        const int *src = mesh.indices + ofs0;
+        for (int k = 0; k < 5; k++)
+          indices[k] = src[k];
+        for (int k = 0; k < 5; k++) {
+          int v = indices[k];
+          if (v < 0 || v >= mesh.numVertices) return false;
+        }
+        v0 = mesh.vertices[indices[0]];
+        v1 = mesh.vertices[indices[1]];
+        v2 = mesh.vertices[indices[2]];
+        v3 = mesh.vertices[indices[3]];
+        v4 = mesh.vertices[indices[4]];
       }
         break;
       case Element::WED: {
-        ints6 indices = (const ints6&)dd.indices[elt.ofs0];
-        v0 = dd.vertices[indices[0]];
-        v1 = dd.vertices[indices[1]];
-        v2 = dd.vertices[indices[2]];
-        v3 = dd.vertices[indices[3]];
-        v4 = dd.vertices[indices[4]];
-        v5 = dd.vertices[indices[5]];
+        int ofs0 = elt.ofs0;
+        if (ofs0 < 0 || (long long)ofs0 + 6 > (long long)mesh.numIndices)
+          return false;
+        ints6 indices;
+        const int *src = mesh.indices + ofs0;
+        for (int k = 0; k < 6; k++)
+          indices[k] = src[k];
+        for (int k = 0; k < 6; k++) {
+          int v = indices[k];
+          if (v < 0 || v >= mesh.numVertices) return false;
+        }
+        v0 = mesh.vertices[indices[0]];
+        v1 = mesh.vertices[indices[1]];
+        v2 = mesh.vertices[indices[2]];
+        v3 = mesh.vertices[indices[3]];
+        v4 = mesh.vertices[indices[4]];
+        v5 = mesh.vertices[indices[5]];
       }
         break;
       case Element::HEX: {
-        ints8 indices = (const ints8&)dd.indices[elt.ofs0];
-        v0 = dd.vertices[indices[0]];
-        v1 = dd.vertices[indices[1]];
-        v2 = dd.vertices[indices[2]];
-        v3 = dd.vertices[indices[3]];
-        v4 = dd.vertices[indices[4]];
-        v5 = dd.vertices[indices[5]];
-        v6 = dd.vertices[indices[6]];
-        v7 = dd.vertices[indices[7]];
+        int ofs0 = elt.ofs0;
+        if (ofs0 < 0 || (long long)ofs0 + 8 > (long long)mesh.numIndices)
+          return false;
+        ints8 indices;
+        const int *src = mesh.indices + ofs0;
+        for (int k = 0; k < 8; k++)
+          indices[k] = src[k];
+        for (int k = 0; k < 8; k++) {
+          int v = indices[k];
+          if (v < 0 || v >= mesh.numVertices) return false;
+        }
+        v0 = mesh.vertices[indices[0]];
+        v1 = mesh.vertices[indices[1]];
+        v2 = mesh.vertices[indices[2]];
+        v3 = mesh.vertices[indices[3]];
+        v4 = mesh.vertices[indices[4]];
+        v5 = mesh.vertices[indices[5]];
+        v6 = mesh.vertices[indices[6]];
+        v7 = mesh.vertices[indices[7]];
       }
         break;
       default:


### PR DESCRIPTION
This PR introduces `BN_UNSTRUCTURED_POLYHEDRON` for the rendering of polyhedral VTU files with the respective patch to haystack, which can be enabled with `HS_USE_VTK`