### PR TITLE
Multi scattering PR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,6 +141,13 @@ endif()
 # ==================================================================
 option(BARNEY_DISABLE_DENOISING "DISable denoising" OFF)
 option(BARNEY_HAVE_NANOVDB "Include Support for NanoVDB" ON)
+option(BARNEY_USE_MULTI_SCATTERING
+  "Enable volumetric multi-scattering (HG phase, volume bounce tracking)"
+  OFF)
+
+if (BARNEY_USE_MULTI_SCATTERING)
+  message("#barney: BARNEY_USE_MULTI_SCATTERING=ON")
+endif()
 
 option(BARNEY_USE_EXTERNAL_CUBQL "Use External CuBQL dir" OFF)
 set(BARNEY_CUBQL_BVH_WIDTH 4 CACHE INT "CuBQL BVH width")

--- a/anari/Renderer.cpp
+++ b/anari/Renderer.cpp
@@ -3,6 +3,7 @@
 
 
 #include "Renderer.h"
+#include "barney/barneyConfig.h"
 
 namespace barney_device {
 
@@ -28,6 +29,10 @@ void Renderer::commitParameters()
   m_background = getParam<math::float4>("background", math::float4(0, 0, 0, 1));
   m_backgroundImage = getParamObject<Array2D>("background");
   m_cutPlane = getParam<math::float4>("cutPlane", math::float4(0, 0, 0, 0));
+#if BARNEY_USE_MULTI_SCATTERING
+  m_maxVolumeBounces = getParam<int>("maxVolumeBounces", 8);
+  m_volumeMultiScatter = getParam<bool>("volumeMultiScatter", false);
+#endif
 }
 
 void Renderer::finalize()
@@ -36,6 +41,10 @@ void Renderer::finalize()
   bnSet1i(barneyRenderer, "crosshairs", (int)m_crosshairs);
   bnSet1i(barneyRenderer, "pathsPerPixel", (int)m_pixelSamples);
   bnSet1f(barneyRenderer, "ambientRadiance", m_ambientRadiance);
+#if BARNEY_USE_MULTI_SCATTERING
+  bnSet1i(barneyRenderer, "maxVolumeBounces", m_maxVolumeBounces);
+  bnSet1i(barneyRenderer, "volumeMultiScatter", (int)m_volumeMultiScatter);
+#endif
   bnSet4f(barneyRenderer, "cutPlane",
           m_cutPlane.x, m_cutPlane.y, m_cutPlane.z, m_cutPlane.w);
 

--- a/anari/Renderer.h
+++ b/anari/Renderer.h
@@ -6,6 +6,7 @@
 
 #include "Array.h"
 #include "Object.h"
+#include "barney/barneyConfig.h"
 
 namespace barney_device {
 
@@ -36,6 +37,10 @@ namespace barney_device {
     bool m_upscale{false};
     anari::math::float4 m_background{0.f, 0.f, 0.f, 1.f};
     anari::math::float4 m_cutPlane{0.f, 0.f, 0.f, -1e30f};
+#if BARNEY_USE_MULTI_SCATTERING
+    int m_maxVolumeBounces{8};
+    bool m_volumeMultiScatter{false};
+#endif
     helium::ChangeObserverPtr<Array2D> m_backgroundImage;
   };
 

--- a/anari/Volume.cpp
+++ b/anari/Volume.cpp
@@ -1,12 +1,24 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-
 #include "Volume.h"
 // std
+#if BARNEY_USE_MULTI_SCATTERING
+#include <algorithm>
+#else
 #include <numeric>
+#endif
 
 namespace barney_device {
+
+#if BARNEY_USE_MULTI_SCATTERING
+  namespace {
+    inline float luminance(const math::float3 &c)
+    {
+      return 0.2126f * c.x + 0.7152f * c.y + 0.0722f * c.z;
+    }
+  }
+#endif
 
   Volume::Volume(BarneyGlobalState *s) : Object(ANARI_VOLUME, s) {}
 
@@ -19,8 +31,11 @@ namespace barney_device {
   {
     if (subtype == "transferFunction1D")
       return new TransferFunction1D(s);
-    else
-      return (Volume *)new UnknownObject(ANARI_VOLUME, subtype, s);
+#if BARNEY_USE_MULTI_SCATTERING
+    if (subtype == "principled_volume")
+      return new PrincipledVolume(s);
+#endif
+    return (Volume *)new UnknownObject(ANARI_VOLUME, subtype, s);
   }
 
   void Volume::markFinalized()
@@ -59,7 +74,9 @@ namespace barney_device {
     return m_visible;
   }
 
-  // Subtypes ///////////////////////////////////////////////////////////////////
+#if !BARNEY_USE_MULTI_SCATTERING
+
+  // TransferFunction1D (main) //////////////////////////////////////////////////
 
   TransferFunction1D::TransferFunction1D(BarneyGlobalState *s)
     : Volume(s), m_field(this), m_colorData(this), m_opacityData(this)
@@ -198,6 +215,336 @@ namespace barney_device {
     cleanup();
     m_boundField = nullptr;
   }
+
+#else
+
+  // FieldMappedVolume //////////////////////////////////////////////////////////
+
+  FieldMappedVolume::FieldMappedVolume(BarneyGlobalState *s)
+    : Volume(s), m_field(this)
+  {}
+
+  bool FieldMappedVolume::isValid() const
+  {
+    return m_field && m_field->isValid();
+  }
+
+  void FieldMappedVolume::commitParameters()
+  {
+    Volume::commitParameters();
+    m_field = getParamObject<SpatialField>("value");
+    m_valueRange = getParam<box1>("valueRange", box1{0.f, 1.f});
+    m_unitDistance = getParam<float>("unitDistance", 1.f);
+    m_anisotropy = getParam<float>("anisotropy", 0.6f);
+    m_scatteringAlbedo = getParam<float>("scatteringAlbedo", 0.9f);
+    invalidateBarneyVolumeIfFieldChanged();
+  }
+
+  void FieldMappedVolume::finalizeFieldMappedVolume()
+  {
+    if (!m_field) {
+      reportMessage(ANARI_SEVERITY_WARNING,
+                    "no spatial field provided to volume");
+      return;
+    }
+
+    if (m_unitDistance <= 0.f) {
+      reportMessage(ANARI_SEVERITY_WARNING,
+                    "invalid density scale calculated from 'unitDistance',"
+                    " setting to 1");
+      m_densityScale = 1.f;
+    } else
+      m_densityScale = 1.f / m_unitDistance;
+
+    m_bounds = m_field->bounds();
+    setBarneyParameters();
+  }
+
+  BNVolume FieldMappedVolume::createBarneyVolume()
+  {
+    int slot = deviceState()->slot;
+    auto context = deviceState()->tether->context;
+
+    BNVolume volume = m_field
+      ? bnVolumeCreate(context, slot, m_field->getBarneyScalarField())
+      : BNVolume{};
+
+    if (volume)
+      m_boundField = m_field.get();
+
+    return volume;
+  }
+
+  box3 FieldMappedVolume::bounds() const
+  {
+    return m_bounds;
+  }
+
+  void FieldMappedVolume::setBarneyParameters()
+  {
+    if (!isValid() || !m_bnVolume)
+      return;
+    BNVolume vol = getBarneyVolume();
+    bnSet1i(vol, "userID", m_id);
+    bnSet1f(vol, "anisotropy", m_anisotropy);
+    bnSet1f(vol, "scatteringAlbedo", m_scatteringAlbedo);
+    bnSet1i(vol, "principledVolume", 0);
+    bnVolumeSetXF(vol,
+                  (bn_float2 &)m_valueRange,
+                  (const bn_float4 *)m_rgbaMap.data(),
+                  (int)m_rgbaMap.size(),
+                  m_densityScale);
+    bnCommit(vol);
+  }
+
+  void FieldMappedVolume::invalidateBarneyVolumeIfFieldChanged()
+  {
+    const SpatialField *newField = m_field.get();
+    if (m_boundField == newField)
+      return;
+
+    cleanup();
+    m_boundField = nullptr;
+  }
+
+  // TransferFunction1D ///////////////////////////////////////////////////////////
+
+  TransferFunction1D::TransferFunction1D(BarneyGlobalState *s)
+    : FieldMappedVolume(s), m_colorData(this), m_opacityData(this)
+  {}
+
+  void TransferFunction1D::commitParameters()
+  {
+    FieldMappedVolume::commitParameters();
+    m_colorData = getParamObject<helium::Array1D>("color");
+    math::float4 uniformColor(1.f);
+    getParam("color", ANARI_FLOAT32_VEC3, &uniformColor);
+    getParam("color", ANARI_FLOAT32_VEC4, &uniformColor);
+    m_uniformColor = uniformColor;
+    m_opacityData = getParamObject<helium::Array1D>("opacity");
+    m_uniformOpacity = getParam<float>("opacity", 1.f) * m_uniformColor.w;
+  }
+
+  void TransferFunction1D::finalize()
+  {
+    if (!m_field) {
+      reportMessage(ANARI_SEVERITY_WARNING,
+                    "no spatial field provided to transferFunction1D volume");
+      return;
+    }
+
+    size_t numColorChannels{4};
+    if (m_colorData) {
+      if (m_colorData->elementType() == ANARI_FLOAT32_VEC3)
+        numColorChannels = 3;
+    }
+
+    float *colorData = m_colorData ? (float *)m_colorData->data() : nullptr;
+    float *opacityData = m_opacityData ? (float *)m_opacityData->data() : nullptr;
+
+    size_t numColors = m_colorData ? m_colorData->size() : 1;
+    size_t numOpacities = m_opacityData ? m_opacityData->size() : 1;
+    size_t tfSize = std::max(numColors, numOpacities);
+
+    m_rgbaMap.resize(tfSize);
+    for (size_t i = 0; i < tfSize; ++i) {
+      float colorPos = tfSize > 1 ? (float(i) / (tfSize - 1)) * (numColors - 1) : 0.f;
+      float colorFrac = colorPos - floorf(colorPos);
+
+      math::float4 color0(m_uniformColor.xyz(), m_uniformOpacity);
+      math::float4 color1(m_uniformColor.xyz(), m_uniformOpacity);
+      if (colorData) {
+        if (numColorChannels == 3) {
+          math::float3 *colors = (math::float3 *)colorData;
+          color0 = math::float4(colors[int(floorf(colorPos))], m_uniformOpacity);
+          color1 = math::float4(colors[int(ceilf(colorPos))], m_uniformOpacity);
+        } else if (numColorChannels == 4) {
+          math::float4 *colors = (math::float4 *)colorData;
+          color0 = colors[int(floorf(colorPos))];
+          color1 = colors[int(ceilf(colorPos))];
+        }
+      }
+
+      math::float4 color = (1.f - colorFrac) * color0 + colorFrac * color1;
+
+      if (opacityData) {
+        float alphaPos = tfSize > 1 ? (float(i) / (tfSize - 1)) * (numOpacities - 1) : 0.f;
+        float alphaFrac = alphaPos - floorf(alphaPos);
+
+        float alpha0 = opacityData[int(floorf(alphaPos))];
+        float alpha1 = opacityData[int(ceilf(alphaPos))];
+
+        color.w *= (1.f - alphaFrac) * alpha0 + alphaFrac * alpha1;
+      }
+
+      m_rgbaMap[i] = color;
+    }
+
+    FieldMappedVolume::finalizeFieldMappedVolume();
+  }
+
+  // PrincipledVolume ///////////////////////////////////////////////////////////
+
+  PrincipledVolume::PrincipledVolume(BarneyGlobalState *s)
+    : FieldMappedVolume(s),
+      m_colorData(this),
+      m_opacityData(this)
+  {}
+
+  void PrincipledVolume::rebuildRGBAMapFromTransferFunction()
+  {
+    size_t numColorChannels{4};
+    if (m_colorData) {
+      if (m_colorData->elementType() == ANARI_FLOAT32_VEC3)
+        numColorChannels = 3;
+    }
+
+    float *colorData = m_colorData ? (float *)m_colorData->data() : nullptr;
+    float *opacityData = m_opacityData ? (float *)m_opacityData->data() : nullptr;
+
+    size_t numColors = m_colorData ? m_colorData->size() : 1;
+    size_t numOpacities = m_opacityData ? m_opacityData->size() : 1;
+    size_t tfSize = std::max(numColors, numOpacities);
+
+    m_rgbaMap.resize(tfSize);
+    for (size_t i = 0; i < tfSize; ++i) {
+      float colorPos = tfSize > 1 ? (float(i) / (tfSize - 1)) * (numColors - 1) : 0.f;
+      float colorFrac = colorPos - floorf(colorPos);
+
+      math::float4 color0(m_uniformColor.xyz(), m_uniformOpacity);
+      math::float4 color1(m_uniformColor.xyz(), m_uniformOpacity);
+      if (colorData) {
+        if (numColorChannels == 3) {
+          math::float3 *colors = (math::float3 *)colorData;
+          color0 = math::float4(colors[int(floorf(colorPos))], m_uniformOpacity);
+          color1 = math::float4(colors[int(ceilf(colorPos))], m_uniformOpacity);
+        } else if (numColorChannels == 4) {
+          math::float4 *colors = (math::float4 *)colorData;
+          color0 = colors[int(floorf(colorPos))];
+          color1 = colors[int(ceilf(colorPos))];
+        }
+      }
+
+      math::float4 color = (1.f - colorFrac) * color0 + colorFrac * color1;
+
+      if (opacityData) {
+        float alphaPos = tfSize > 1 ? (float(i) / (tfSize - 1)) * (numOpacities - 1) : 0.f;
+        float alphaFrac = alphaPos - floorf(alphaPos);
+
+        float alpha0 = opacityData[int(floorf(alphaPos))];
+        float alpha1 = opacityData[int(ceilf(alphaPos))];
+
+        color.w *= (1.f - alphaFrac) * alpha0 + alphaFrac * alpha1;
+      }
+
+      m_rgbaMap[i] = color;
+    }
+  }
+
+  void PrincipledVolume::commitParameters()
+  {
+    FieldMappedVolume::commitParameters();
+    m_density = getParam<float>("density", 1.f);
+    m_color = getParam<math::float3>("scatterColor",
+                                     getParam<math::float3>("color",
+                                                            math::float3(0.8f)));
+    m_absorptionColor = getParam<math::float3>("absorptionColor", math::float3(0.f));
+    m_densityThreshold = getParam<float>("densityThreshold", 0.f);
+    m_emissionStrength = getParam<float>("emissionStrength", 0.f);
+    m_emissionColor = getParam<math::float3>("emissionColor", math::float3(1.f));
+    m_blackbodyIntensity = getParam<float>("blackbodyIntensity", 0.f);
+    m_blackbodyTint = getParam<math::float3>("blackbodyTint", math::float3(1.f));
+    m_temperature = getParam<float>("temperature", 0.f);
+
+    m_colorData = getParamObject<helium::Array1D>("color");
+    math::float4 uniformColor(1.f);
+    getParam("color", ANARI_FLOAT32_VEC3, &uniformColor);
+    getParam("color", ANARI_FLOAT32_VEC4, &uniformColor);
+    m_uniformColor = uniformColor;
+    m_opacityData = getParamObject<helium::Array1D>("opacity");
+    m_uniformOpacity = getParam<float>("opacity", 1.f) * m_uniformColor.w;
+    rebuildRGBAMapFromTransferFunction();
+
+    if (!hasParam("scatteringAlbedo")) {
+      float absorb = luminance(m_absorptionColor);
+      m_scatteringAlbedo = absorb < 0.f ? 0.f : (absorb > 1.f ? 1.f : 1.f - absorb);
+    }
+
+    if (m_unitDistance <= 0.f)
+      m_densityScale = 1.f;
+    else
+      m_densityScale = 1.f / m_unitDistance;
+
+    if (m_bnVolume)
+      setBarneyParameters();
+  }
+
+  void PrincipledVolume::setBarneyParameters()
+  {
+    if (!isValid())
+      return;
+
+    if (m_unitDistance <= 0.f)
+      m_densityScale = 1.f;
+    else
+      m_densityScale = 1.f / m_unitDistance;
+
+    if (!m_bnVolume)
+      return;
+
+    BNVolume vol = m_bnVolume;
+    bnSet1i(vol, "userID", m_id);
+    bnSet1f(vol, "anisotropy", m_anisotropy);
+    bnSet1f(vol, "scatteringAlbedo", m_scatteringAlbedo);
+    bnSet1i(vol, "principledVolume", 1);
+    bnSet1f(vol, "principledDensity", m_density);
+    bnSet3f(vol, "principledScatterColor", m_color.x, m_color.y, m_color.z);
+    bnSet3f(vol, "principledAbsorptionColor",
+            m_absorptionColor.x, m_absorptionColor.y, m_absorptionColor.z);
+    bnSet1f(vol, "principledDensityThreshold", m_densityThreshold);
+    bnSet1f(vol, "principledDensityScale", m_densityScale);
+    bnSet2f(vol, "principledValueRange", m_valueRange.lower, m_valueRange.upper);
+    bnSet1f(vol, "principledEmissionStrength", m_emissionStrength);
+    bnSet3f(vol, "principledEmissionColor",
+            m_emissionColor.x, m_emissionColor.y, m_emissionColor.z);
+    bnSet1f(vol, "principledBlackbodyIntensity", m_blackbodyIntensity);
+    bnSet3f(vol, "principledBlackbodyTint",
+            m_blackbodyTint.x, m_blackbodyTint.y, m_blackbodyTint.z);
+    bnSet1f(vol, "principledTemperature", m_temperature);
+
+    if (!m_rgbaMap.empty()) {
+      bnVolumeSetXF(vol,
+                    (bn_float2 &)m_valueRange,
+                    (const bn_float4 *)m_rgbaMap.data(),
+                    (int)m_rgbaMap.size(),
+                    m_densityScale);
+    }
+    bnCommit(vol);
+  }
+
+  void PrincipledVolume::finalize()
+  {
+    if (!m_field) {
+      reportMessage(ANARI_SEVERITY_WARNING,
+                    "no spatial field provided to principled_volume");
+      return;
+    }
+
+    rebuildRGBAMapFromTransferFunction();
+
+    if (m_unitDistance <= 0.f) {
+      reportMessage(ANARI_SEVERITY_WARNING,
+                    "invalid density scale calculated from 'unitDistance',"
+                    " setting to 1");
+      m_densityScale = 1.f;
+    } else
+      m_densityScale = 1.f / m_unitDistance;
+
+    m_bounds = m_field->bounds();
+    setBarneyParameters();
+  }
+
+#endif
 
 } // namespace barney_device
 

--- a/anari/Volume.h
+++ b/anari/Volume.h
@@ -7,6 +7,9 @@
 #include "Array.h"
 #include "Object.h"
 #include "SpatialField.h"
+#include "barney/barneyConfig.h"
+
+#include <vector>
 
 namespace barney_device {
 
@@ -37,6 +40,81 @@ namespace barney_device {
   };
 
   // Subtypes ///////////////////////////////////////////////////////////////////
+
+#if BARNEY_USE_MULTI_SCATTERING
+
+  struct FieldMappedVolume : public Volume
+  {
+    FieldMappedVolume(BarneyGlobalState *s);
+
+    void commitParameters() override;
+    bool isValid() const override;
+
+    BNVolume createBarneyVolume() override;
+    box3 bounds() const override;
+
+  protected:
+    void setBarneyParameters() override;
+    void invalidateBarneyVolumeIfFieldChanged();
+    void finalizeFieldMappedVolume();
+
+    helium::ChangeObserverPtr<SpatialField> m_field;
+    const SpatialField *m_boundField{nullptr};
+
+    box3 m_bounds;
+    box1 m_valueRange{0.f, 1.f};
+    float m_unitDistance{1.f};
+    float m_densityScale{1.f};
+    float m_anisotropy{0.6f};
+    float m_scatteringAlbedo{0.9f};
+    std::vector<math::float4> m_rgbaMap;
+  };
+
+  struct TransferFunction1D : public FieldMappedVolume
+  {
+    TransferFunction1D(BarneyGlobalState *s);
+
+    void commitParameters() override;
+    void finalize() override;
+
+  private:
+    math::float4 m_uniformColor{1.f, 1.f, 1.f, 1.f};
+    float m_uniformOpacity{1.f};
+
+    helium::ChangeObserverPtr<helium::Array1D> m_colorData;
+    helium::ChangeObserverPtr<helium::Array1D> m_opacityData;
+  };
+
+  struct PrincipledVolume : public FieldMappedVolume
+  {
+    PrincipledVolume(BarneyGlobalState *s);
+
+    void commitParameters() override;
+    void finalize() override;
+
+  protected:
+    void setBarneyParameters() override;
+
+  private:
+    float m_density{1.f};
+    math::float3 m_color{0.8f, 0.8f, 0.8f};
+    math::float3 m_absorptionColor{0.f, 0.f, 0.f};
+    float m_densityThreshold{0.f};
+    float m_emissionStrength{0.f};
+    math::float3 m_emissionColor{1.f, 1.f, 1.f};
+    float m_blackbodyIntensity{0.f};
+    math::float3 m_blackbodyTint{1.f, 1.f, 1.f};
+    float m_temperature{0.f};
+
+    math::float4 m_uniformColor{1.f, 1.f, 1.f, 1.f};
+    float m_uniformOpacity{1.f};
+    helium::ChangeObserverPtr<helium::Array1D> m_colorData;
+    helium::ChangeObserverPtr<helium::Array1D> m_opacityData;
+
+    void rebuildRGBAMapFromTransferFunction();
+  };
+
+#else
 
   struct TransferFunction1D : public Volume
   {
@@ -71,6 +149,8 @@ namespace barney_device {
 
     std::vector<math::float4> m_rgbaMap;
   };
+
+#endif
 
 } // namespace barney_device
 

--- a/barney/common/barneyConfig.h.in
+++ b/barney/common/barneyConfig.h.in
@@ -5,6 +5,8 @@
 
 #cmakedefine01 BARNEY_DISABLE_DENOISING
 
+#cmakedefine01 BARNEY_USE_MULTI_SCATTERING
+
 /*! whether this build of barney has support for the NanoVDB volume
     type. NanoVDB takes a long while to compile, so can be
     enabled/disabled by user */

--- a/barney/kernels/generateRays.cu
+++ b/barney/kernels/generateRays.cu
@@ -198,6 +198,9 @@ namespace BARNEY_NS {
       }
       // ray.rngSeed     = rand.next;//state;
       state.numDiffuseBounces = 0;
+#if BARNEY_USE_MULTI_SCATTERING
+      state.numVolumeBounces = 0;
+#endif
       if (0 && ray.dbg())
         printf("-------------------------------------------------------\n");
              

--- a/barney/kernels/shadeRays.cu
+++ b/barney/kernels/shadeRays.cu
@@ -10,17 +10,20 @@
 #include "barney/GlobalModel.h"
 #include "barney/render/RayQueue.h"
 #include "rtcore/TraceInterface.h"
+#include "barney/barneyConfig.h"
 
 namespace BARNEY_NS {
   namespace render {
 
-#define SCI_VIS_MODE 1
-    
 #define MAX_DIFFUSE_BOUNCES 1
     
 #define ENV_LIGHT_SAMPLING 1
 
 #define USE_MIS 1
+
+#if !BARNEY_USE_MULTI_SCATTERING
+#define SCI_VIS_MODE 1
+#endif
 
 
 #define CLAMP_F_R 13.f
@@ -439,8 +442,8 @@ namespace BARNEY_NS {
       auto &env = world.envMapLight;
       if (env.texture) {
         vec3f d = xfmVector(env.toLocal,normalize(ray.dir));
-        float theta = pbrtSphericalTheta(d);
-        float phi   = pbrtSphericalPhi(d);
+        float theta = sphericalTheta(d);
+        float phi   = sphericalPhi(d);
         const float invPi  = 1.f/(float)M_PI;
         const float inv2Pi = 1.f/(2.f* (float)M_PI);
         vec2f uv(phi * inv2Pi, theta * invPi);
@@ -607,6 +610,15 @@ namespace BARNEY_NS {
       Random random(ray.rngSeed,(const uint32_t&)ray.tMax);//rayID,ray.rngSeed);
       // Random random(ray.rngSeed.next((const uint32_t&)ray.tMax));//rayID,ray.rngSeed);
       const PackedBSDF bsdf = ray.getBSDF();
+
+#if BARNEY_USE_MULTI_SCATTERING
+      if (isVolumeHit && bsdf.type == PackedBSDF::TYPE_Phase) {
+        vec3f emission = (vec3f)bsdf.data.phase.emission;
+        if (reduce_max(emission) > 0.f)
+          fragment = incomingThroughput * emission;
+      }
+#endif
+
       // bool doTransmission = false;
       // =  ((float)ray.mini.transmission > 0.f)
       // && (random() < (float)ray.mini.transmission);
@@ -761,6 +773,17 @@ namespace BARNEY_NS {
         return;
       
       if (scatterResult.type == ScatterResult::VOLUME) {
+#if BARNEY_USE_MULTI_SCATTERING
+        if (!renderer.volumeMultiScatter) {
+          ray.tMax = -1.f;
+          return;
+        }
+        if (state.numVolumeBounces >= renderer.maxVolumeBounces) {
+          ray.tMax = -1.f;
+          return;
+        }
+        state.numVolumeBounces = state.numVolumeBounces + 1;
+#else
 #if SCI_VIS_MODE
         // sci vis mode: volumes do shadow, but nothing more
         ray.tMax = -1.f;
@@ -769,15 +792,20 @@ namespace BARNEY_NS {
         // treat volume scatter like a diffuse scatter.
         scatterResult.type = ScatterResult::DIFFUSE;
 #endif
+#endif
       }
       
+#if BARNEY_USE_MULTI_SCATTERING
+      if (scatterResult.type == ScatterResult::DIFFUSE) {
+#else
       if (scatterResult.type == ScatterResult::DIFFUSE ||
           scatterResult.type == ScatterResult::VOLUME) {
+#endif
         if (state.numDiffuseBounces >= MAX_DIFFUSE_BOUNCES) {
           ray.tMax = -1.f;
           return;
-        } else
-          state.numDiffuseBounces = state.numDiffuseBounces + 1;
+        }
+        state.numDiffuseBounces = state.numDiffuseBounces + 1;
       }
       ray.isSpecular = (scatterResult.type == ScatterResult::SPECULAR);
       

--- a/barney/light/EnvMap.h
+++ b/barney/light/EnvMap.h
@@ -162,29 +162,13 @@ namespace BARNEY_NS {
     return pdf_x * pdf_y * 1.f/(TWO_PI*ONE_PI*sinf(theta));
   }
   
-  inline __rtc_device float pbrt_clampf(float f, float lo, float hi)
-  {
-    return max(lo,min(hi,f));
-  }
-  
-  inline __rtc_device float pbrtSphericalTheta(const vec3f &v)
-  {
-    return acosf(pbrt_clampf(v.z, -1.f, 1.f));
-  }
-  
-  inline __rtc_device float pbrtSphericalPhi(const vec3f &v)
-  {
-    float p = atan2f(v.y, v.x);
-    return (p < 0.f) ? (p + float(2.f * M_PI)) : p;
-  }
-
   inline __rtc_device vec2i
   EnvMapLight::DD::worldToPixel(vec3f worldDir) const
   {
     vec3f localDir = xfmVector(toLocal,worldDir);
     
-    float theta = pbrtSphericalTheta(localDir);
-    float phi   = pbrtSphericalPhi(localDir);
+    float theta = render::sphericalTheta(localDir);
+    float phi   = render::sphericalPhi(localDir);
     const float invPi  = ONE_OVER_PI;
     const float inv2Pi = ONE_OVER_TWO_PI;
     vec2f uv(phi * inv2Pi, theta * invPi);

--- a/barney/packedBSDF/Phase.h
+++ b/barney/packedBSDF/Phase.h
@@ -5,11 +5,114 @@
 #pragma once
 
 #include "barney/render/DG.h"
+#include "barney/barneyConfig.h"
 
 namespace BARNEY_NS {
   namespace render {
     namespace packedBSDF {
 
+#if BARNEY_USE_MULTI_SCATTERING
+      /*! homogeneous phase function with Henyey-Greenstein anisotropy. */
+      struct Phase {
+        inline Phase() = default;
+        inline __rtc_device Phase(vec3f color, float scatteringAlbedo=.9f,
+                                  float g=0.f);
+
+        inline __rtc_device
+        float pdf(DG dg, vec3f wi, bool dbg) const;
+        
+        inline __rtc_device
+        EvalRes eval(DG dg, vec3f wi, bool dbg) const;
+        
+        inline __rtc_device
+        void scatter(ScatterResult &scatter,
+                     const render::DG &dg,
+                     Random &random,
+                     bool dbg) const;
+
+        inline __rtc_device
+        float hgPhase(float cosTheta) const;
+        
+        rtc::float3 albedo;
+        float g;
+        rtc::float3 emission;
+      };
+
+      inline __rtc_device
+      Phase::Phase(vec3f color, float scatteringAlbedo, float _g)
+      {
+        (vec3f&)this->albedo = scatteringAlbedo * color;
+        this->g = _g;
+        (vec3f&)this->emission = vec3f(0.f);
+      }
+
+      inline __rtc_device
+      float Phase::hgPhase(float cosTheta) const
+      {
+        if (fabsf(g) < 1e-3f)
+          return ONE_OVER_FOUR_PI;
+        float g2 = g*g;
+        float denom = 1.f + g2 - 2.f*g*cosTheta;
+        return ONE_OVER_FOUR_PI * (1.f - g2) / (denom * sqrtf(denom));
+      }
+      
+      inline __rtc_device
+      float Phase::pdf(DG dg, vec3f wi, bool dbg) const
+      {
+        vec3f wi_in = normalize(-dg.wo);
+        float cosTheta = dot(wi_in, normalize(wi));
+        return hgPhase(cosTheta);
+      }
+        
+      inline __rtc_device
+      EvalRes Phase::eval(DG dg, vec3f wi, bool dbg) const
+      {
+        float density = pdf(dg, wi, dbg);
+        return EvalRes(density * (const vec3f&)albedo, density);
+      }
+
+      inline __rtc_device
+      vec3f sampleHGDirection(vec3f wi_in, float g, Random &random)
+      {
+        float u0 = random();
+        float u1 = random();
+        float cosTheta;
+        if (fabsf(g) < 1e-3f)
+          cosTheta = 1.f - 2.f*u0;
+        else {
+          float sqrTerm = (1.f - g*g) / (1.f + g - 2.f*g*u0);
+          cosTheta = (1.f + g*g - sqrTerm*sqrTerm) / (2.f * g);
+        }
+        float sinTheta = sqrtf(max(0.f, 1.f - cosTheta*cosTheta));
+        float phi = TWO_PI * u1;
+        vec3f local = vec3f(cosf(phi)*sinTheta,
+                            sinf(phi)*sinTheta,
+                            cosTheta);
+        vec3f w = normalize(wi_in);
+        vec3f u, v;
+        if (fabsf(w.x) > 0.1f)
+          u = normalize(cross(vec3f(0.f,1.f,0.f), w));
+        else
+          u = normalize(cross(vec3f(1.f,0.f,0.f), w));
+        v = cross(w, u);
+        return normalize(local.x*u + local.y*v + local.z*w);
+      }
+
+      inline __rtc_device
+      void Phase::scatter(ScatterResult &scatter,
+                          const render::DG &dg,
+                          Random &random,
+                          bool dbg) const
+      {
+        vec3f wi_in = normalize(-dg.wo);
+        scatter.dir = sampleHGDirection(wi_in, g, random);
+        float density = hgPhase(dot(wi_in, scatter.dir));
+        scatter.pdf = density;
+        scatter.f_r = (const vec3f&)albedo * density;
+        scatter.type = ScatterResult::VOLUME;
+      }
+
+#else
       /*! implements a homogenous phase function that scatters equally
           in all directions, with given average reflectance and
           color */
@@ -50,19 +153,14 @@ namespace BARNEY_NS {
                        (const vec3f&)albedo,density);
       }
 
-      /*! simple omnidirectional phase function - scatter into any
-        random direction */
       inline __rtc_device
       void Phase::scatter(ScatterResult &scatter,
                           const render::DG &dg,
                           Random &random,
                           bool dbg) const
       {
-        // see global illumination compendium, page 19
         float r1 = random();
         float r2 = random(); 
-        // float phi = two_pi*r1;
-        // float theta = acosf(1.f-2.f*r2);
         float x = cosf(TWO_PI*r1)*sqrtf(r2*(1.f-r2));
         float y = sinf(TWO_PI*r1)*sqrtf(r2*(1.f-r2));
         float z = (1.f-2.f*r2);
@@ -72,8 +170,8 @@ namespace BARNEY_NS {
         scatter.dir = vec3f(x,y,z);
         scatter.type = ScatterResult::VOLUME;
       }
+#endif
       
     }
   }
 }
-

--- a/barney/render/DG.h
+++ b/barney/render/DG.h
@@ -93,15 +93,13 @@ namespace BARNEY_NS {
       }
     }
 
-    inline __rtc_device float pbrt_clampf(float f, float lo, float hi)
-    { return max(lo,min(hi,f)); }
-
-    inline __rtc_device float pbrtSphericalTheta(const vec3f &v)
+    /*! Spherical coordinates for unit direction v (theta = polar angle from +Z). */
+    inline __rtc_device float sphericalTheta(const vec3f &v)
     {
-      return acosf(pbrt_clampf(v.z, -1.f, 1.f));
+      return acosf(clamp(v.z, -1.f, 1.f));
     }
 
-    inline __rtc_device float pbrtSphericalPhi(const vec3f &v)
+    inline __rtc_device float sphericalPhi(const vec3f &v)
     {
       float p = atan2f(v.y, v.x);
       return (p < 0.f) ? (p + float(2.f * M_PI)) : p;

--- a/barney/render/Ray.h
+++ b/barney/render/Ray.h
@@ -7,6 +7,7 @@
 #include "barney/common/half.h"
 #include "barney/packedBSDF/PackedBSDF.h"
 #include "barney/common/random.h"
+#include "barney/barneyConfig.h"
 
 namespace BARNEY_NS {
   namespace render {
@@ -19,6 +20,9 @@ namespace BARNEY_NS {
       int32_t  pixelID;
       float    misWeight;
       int      numDiffuseBounces;
+#if BARNEY_USE_MULTI_SCATTERING
+      int      numVolumeBounces;
+#endif
     };
 
     struct RayOnly {
@@ -36,20 +40,26 @@ namespace BARNEY_NS {
 
     struct HitOnly {
       float tHit;
-      /*! the actual hit point, in 3D float coordinates (rather than
-        implicitly through org+tMax*dir), for numerical robustness
-        issues */
       vec3f       P;
       vec3h       N;
-      /*! type of bsdf in the hitBSDF; if this is set to NONE the
-        ray didn't have any hit yet */
       uint16_t bsdfType   : 4;
       PackedBSDF::Data hitBSDF;
     };
     
     struct Ray {
 #if RTC_DEVICE_CODE
+#if BARNEY_USE_MULTI_SCATTERING
+      inline __rtc_device void setVolumeHit(vec3f P, float t, vec3f albedo,
+                                            float anisotropy,
+                                            float scatteringAlbedo);
+      inline __rtc_device void setVolumeHitWithEmission(vec3f P, float t,
+                                                        vec3f albedo,
+                                                        float anisotropy,
+                                                        float scatteringAlbedo,
+                                                        vec3f emission);
+#else
       inline __rtc_device void setVolumeHit(vec3f P, float t, vec3f albedo);
+#endif
       inline __rtc_device PackedBSDF getBSDF() const;
       inline __rtc_device void setHit(vec3f P, vec3f N, float t,
                                     const PackedBSDF &packedBSDF);
@@ -68,18 +78,10 @@ namespace BARNEY_NS {
       float   tMax;
       RNGSeed rngSeed;
 
-      /*! the actual hit point, in 3D float coordinates (rather than
-        implicitly through org+tMax*dir), for numerical robustness
-        issues */
       vec3f       P;
       vec3h       N;
       struct {
-        /*! type of bsdf in the hitBSDF; if this is set to NONE the
-          ray didn't have any hit yet */
         uint16_t bsdfType   : 4;
-        // uint16_t numDiffuseBounces: 4;
-        /*! for path tracer: tracks whether we are, or aren't, in a
-          refractable medium */
         uint16_t isInMedium : 1;
         uint16_t isSpecular : 1;
         uint16_t isShadowRay: 1;
@@ -92,9 +94,6 @@ namespace BARNEY_NS {
       
       union {
         PackedBSDF::Data hitBSDF;
-        /*! the background color for primary rays that didn't have any intersection.
-          do not use float4 here since that might incur padding for alignment reasosn.
-         */
         bn_float4 missColor;
       };
     };
@@ -115,17 +114,40 @@ namespace BARNEY_NS {
       this->P         = P;
     }
     
+#if BARNEY_USE_MULTI_SCATTERING
+    inline __rtc_device void Ray::setVolumeHit(vec3f P,
+                                             float t,
+                                             vec3f albedo,
+                                             float anisotropy,
+                                             float scatteringAlbedo)
+    {
+      if (this->dbg()) printf("setting volume hit %f %f %f g=%f\n",
+                            albedo.x, albedo.y, albedo.z, anisotropy);
+      setHit(P, vec3f(0.f), t,
+             packedBSDF::Phase(albedo, scatteringAlbedo, anisotropy));
+    }
+
+    inline __rtc_device void Ray::setVolumeHitWithEmission(vec3f P,
+                                                           float t,
+                                                           vec3f albedo,
+                                                           float anisotropy,
+                                                           float scatteringAlbedo,
+                                                           vec3f emission)
+    {
+      packedBSDF::Phase phase(albedo, scatteringAlbedo, anisotropy);
+      (vec3f&)phase.emission = emission;
+      setHit(P, vec3f(0.f), t, phase);
+    }
+#else
     inline __rtc_device void Ray::setVolumeHit(vec3f P,
                                              float t,
                                              vec3f albedo)
     {
       if (this->dbg()) printf("setting volume hit %f %f %f\n",
-                            albedo.x,
-                            albedo.y,
-                            albedo.z);
-      setHit(P,vec3f(0.f),t,
-             packedBSDF::Phase(albedo));
+                            albedo.x, albedo.y, albedo.z);
+      setHit(P, vec3f(0.f), t, packedBSDF::Phase(albedo));
     }
+#endif
 
     inline __rtc_device
     void makeShadowRay(Ray &ray,

--- a/barney/render/Renderer.cpp
+++ b/barney/render/Renderer.cpp
@@ -4,6 +4,7 @@
 
 #include "barney/render/Renderer.h"
 #include "barney/Context.h"
+#include "barney/barneyConfig.h"
 
 namespace BARNEY_NS {
 
@@ -29,6 +30,10 @@ namespace BARNEY_NS {
     pathsPerPixel   = staged.pathsPerPixel;
     bgTexture       = staged.bgTexture;
     cutPlane        = staged.cutPlane;
+#if BARNEY_USE_MULTI_SCATTERING
+    maxVolumeBounces = staged.maxVolumeBounces;
+    volumeMultiScatter = staged.volumeMultiScatter;
+#endif
   }
   
   bool Renderer::setObject(const std::string &member,
@@ -66,6 +71,16 @@ namespace BARNEY_NS {
       staged.crosshairs = value;
       return true;
     }
+#if BARNEY_USE_MULTI_SCATTERING
+    if (member == "maxVolumeBounces") {
+      staged.maxVolumeBounces = value;
+      return true;
+    }
+    if (member == "volumeMultiScatter") {
+      staged.volumeMultiScatter = value;
+      return true;
+    }
+#endif
     return false;
   }
   
@@ -94,6 +109,10 @@ namespace BARNEY_NS {
     dd.ambientRadiance = ambientRadiance;
     dd.pathsPerPixel = pathsPerPixel;
     dd.cutPlane = cutPlane;
+#if BARNEY_USE_MULTI_SCATTERING
+    dd.maxVolumeBounces = maxVolumeBounces;
+    dd.volumeMultiScatter = volumeMultiScatter;
+#endif
     return dd;
   }
   

--- a/barney/render/Renderer.h
+++ b/barney/render/Renderer.h
@@ -6,6 +6,7 @@
 
 #include "barney/Object.h"
 #include "barney/common/Texture.h"
+#include "barney/barneyConfig.h"
 
 namespace BARNEY_NS {
 
@@ -22,6 +23,10 @@ namespace BARNEY_NS {
       float              ambientRadiance;
       int                pathsPerPixel;
       vec4f              cutPlane;
+#if BARNEY_USE_MULTI_SCATTERING
+      int                maxVolumeBounces;
+      int                volumeMultiScatter;
+#endif
     };
     
     Renderer(Context *context);
@@ -52,6 +57,10 @@ namespace BARNEY_NS {
       float       ambientRadiance = 1.f;
       int         crosshairs      = 0;
       vec4f       cutPlane        = vec4f(0,0,0,-1e30f);
+#if BARNEY_USE_MULTI_SCATTERING
+      int         maxVolumeBounces = 8;
+      int         volumeMultiScatter = 1;
+#endif
     } staged;
     vec4f       bgColor         = vec4f(0,0,0,1.f);
     Texture::SP bgTexture       = 0;
@@ -59,6 +68,10 @@ namespace BARNEY_NS {
     float       ambientRadiance = 1.f;
     int         crosshairs      = 0;
     vec4f       cutPlane        = vec4f(0,0,0,-1e30f);
+#if BARNEY_USE_MULTI_SCATTERING
+    int         maxVolumeBounces = 8;
+    int         volumeMultiScatter = 1;
+#endif
   };
 
 }

--- a/barney/umesh/os/AWT.cu
+++ b/barney/umesh/os/AWT.cu
@@ -265,6 +265,10 @@ namespace BARNEY_NS {
     dd.xf       = this->volume->xf.getDD(device);
     dd.primIDs  = pld->primIDs;
     dd.userID   = volume->userID;
+#if BARNEY_USE_MULTI_SCATTERING
+    dd.anisotropy = volume->anisotropy;
+    dd.scatteringAlbedo = volume->scatteringAlbedo;
+#endif
     return dd;
   }
 

--- a/barney/umesh/os/AWT.dev.cu
+++ b/barney/umesh/os/AWT.dev.cu
@@ -466,8 +466,16 @@ namespace BARNEY_NS {
                           int(stack-stackBase));
           if (stack == stackBase) {
             if (tHit < ray.tMax) {
+#if BARNEY_USE_MULTI_SCATTERING
+              ray.setVolumeHit(org+tHit*dir,
+                               tHit,
+                               (const vec3f&)sample,
+                               self.anisotropy,
+                               self.scatteringAlbedo);
+#else
               ray.setVolumeHit(org+tHit*dir,
                                tHit,(const vec3f&)sample);
+#endif
             }
             return;
             // done = true;

--- a/barney/umesh/os/AWT.h
+++ b/barney/umesh/os/AWT.h
@@ -6,6 +6,7 @@
 
 #include "barney/umesh/common/UMeshField.h"
 #include "barney/volume/Volume.h"
+#include "barney/barneyConfig.h"
 
 // #define AWT_DEFAULT_MAX_DEPTH 7
 #define AWT_NODE_WIDTH 4
@@ -46,6 +47,10 @@ namespace BARNEY_NS {
       AWTNode              *awtNodes;
       uint32_t             *primIDs;
       int                   userID;
+#if BARNEY_USE_MULTI_SCATTERING
+      float                 anisotropy;
+      float                 scatteringAlbedo;
+#endif
     };
 
     struct PLD {

--- a/barney/umesh/os/ObjectSpace-common.h
+++ b/barney/umesh/os/ObjectSpace-common.h
@@ -6,6 +6,7 @@
 
 #include "barney/umesh/common/UMeshField.h"
 #include "barney/common/CUBQL.h"
+#include "barney/barneyConfig.h"
 #include "barney/render/Ray.h"
 
 namespace barney {
@@ -836,7 +837,15 @@ namespace barney {
         // ray.tMax = t;
         inputLeafRange.upper = min(inputLeafRange.upper,hit_t);
         vec3f P = ray.org + t * ray.dir;
+#if BARNEY_USE_MULTI_SCATTERING
+        ray.setVolumeHit(P,
+                         t,
+                         getPos(mapped),
+                         self.volume.anisotropy,
+                         self.volume.scatteringAlbedo);
+#else
         ray.setVolumeHit(P,t,getPos(mapped));
+#endif
         break;
       }
     }
@@ -881,7 +890,15 @@ namespace barney {
 
         isec.leafRange.upper = hit_t;
         hit_t = t;
+#if BARNEY_USE_MULTI_SCATTERING
+        ray.setVolumeHit(P,
+                         t,
+                         getPos(isec.mapped),
+                         self.volume.anisotropy,
+                         self.volume.scatteringAlbedo);
+#else
         ray.setVolumeHit(P,t,getPos(isec.mapped));
+#endif
         break;
       }
     } 

--- a/barney/volume/MCAccelerator.h
+++ b/barney/volume/MCAccelerator.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "barney/common/barney-common.h"
+#include "barney/barneyConfig.h"
 #include "barney/DeviceGroup.h"
 #include "barney/volume/MCGrid.h"
 #include "barney/volume/Volume.h"
@@ -20,7 +21,7 @@
 namespace BARNEY_NS {
   using render::Ray;
   using render::DeviceMaterial;
- 
+
   template<typename SFSampler>
   struct MCVolumeAccel : public VolumeAccel 
   {
@@ -54,6 +55,12 @@ namespace BARNEY_NS {
       GeomTypeCreationFct const creatorFct;
     
     void build(bool full_rebuild) override;
+
+#if BARNEY_USE_MULTI_SCATTERING
+    void rebuildMajorantsOnly() override;
+
+    void refreshDeviceData() override;
+#endif
 
 #if BARNEY_DEVICE_PROGRAM
     /*! optix bounds prog for this class of accels */
@@ -126,6 +133,34 @@ namespace BARNEY_NS {
   // INLINE IMPLEMENTATION SECTION
   // ==================================================================
   
+#if BARNEY_USE_MULTI_SCATTERING
+  template<typename SFSampler>
+  void MCVolumeAccel<SFSampler>::rebuildMajorantsOnly()
+  {
+    if (!majorantsGrid)
+      return;
+    if (!volume->sf->mcGrid || !volume->sf->mcGrid->built())
+      return;
+    majorantsGrid->computeMajorants(volume);
+    refreshDeviceData();
+  }
+
+  template<typename SFSampler>
+  void MCVolumeAccel<SFSampler>::refreshDeviceData()
+  {
+    for (auto device : *devices) {
+      SetActiveGPU forDuration(device);
+      PLD *pld = getPLD(device);
+      if (!pld->geom)
+        continue;
+      DD dd = getDD(device);
+      pld->geom->setDD(&dd);
+    }
+    for (auto device : *devices)
+      device->sbtDirty = true;
+  }
+#endif
+
   template<typename SFSampler>
   void MCVolumeAccel<SFSampler>::build(bool full_rebuild) 
   {
@@ -133,7 +168,11 @@ namespace BARNEY_NS {
       auto mcGrid = volume->sf->getMCs();
       majorantsGrid = std::make_shared<MajorantsGrid>(mcGrid);
     }
+#if BARNEY_USE_MULTI_SCATTERING
+    majorantsGrid->computeMajorants(volume);
+#else
     majorantsGrid->computeMajorants(&volume->xf);
+#endif
     sfSampler->build();
     
     for (auto device : *devices) {
@@ -572,9 +611,6 @@ namespace BARNEY_NS {
 
     Random rng(ray.rngSeed,hash(ti.getRTCInstanceIndex(),
                                 ti.getGeometryIndex(),0));
-    // Random rng(ray.rngSeed,hash(ti.getRTCInstanceIndex(),
-    //                             ti.getGeometryIndex(),
-    //                             ti.getPrimitiveIndex()));
     dda::dda3(dda_org,dda_dir,tRange.upper,
               vec3ui(self.mcGrid.dims),
               [&](const vec3i &cellIdx, float t0, float t1) -> bool
@@ -602,9 +638,50 @@ namespace BARNEY_NS {
                 
                 vec3f P_obj = obj_org + tRange.upper * obj_dir;
                 vec3f P = ti.transformPointFromObjectToWorldSpace(P_obj);
+#if BARNEY_USE_MULTI_SCATTERING
+                vec3f tint = getPos(sample);
+                vec3f emission = vec3f(0.f);
+                float hitScatteringAlbedo = self.volume.scatteringAlbedo;
+                if (self.volume.principled.enabled) {
+                  float scalar = self.volume.sampleScalar(P_obj, dbg);
+                  vec3f sigma_s = principledSigmaS(scalar, self.volume.principled);
+                  vec3f sigma_a = principledSigmaA(scalar, self.volume.principled);
+                  vec4f tf = self.volume.xf.map(scalar, dbg);
+                  if (tf.w > 0.f) {
+                    sigma_s = sigma_s * tf.w;
+                    sigma_a = sigma_a * tf.w;
+                    tint = tint * getPos(tf);
+                  } else {
+                    sigma_s = vec3f(0.f);
+                    sigma_a = vec3f(0.f);
+                  }
+                  float sigma_t = reduce_max(sigma_s + sigma_a);
+                  if (sigma_t > 0.f) {
+                    float ms = reduce_max(sigma_s);
+                    tint = ms > 0.f ? sigma_s / ms : tint;
+                    hitScatteringAlbedo = reduce_max(sigma_s) / sigma_t;
+                  }
+                  emission = principledEmission(scalar, self.volume.principled);
+                }
+                if (reduce_max(emission) > 0.f) {
+                  ray.setVolumeHitWithEmission(P,
+                                               tRange.upper,
+                                               tint,
+                                               self.volume.anisotropy,
+                                               hitScatteringAlbedo,
+                                               emission);
+                } else {
+                  ray.setVolumeHit(P,
+                                   tRange.upper,
+                                   tint,
+                                   self.volume.anisotropy,
+                                   hitScatteringAlbedo);
+                }
+#else
                 ray.setVolumeHit(P,
                                  tRange.upper,
                                  getPos(sample));
+#endif
 
                 // Write hit IDs for AOV channels on first non-transparent voxel
                 const render::OptixGlobals &globals = render::OptixGlobals::get(ti);

--- a/barney/volume/MCGrid.cu
+++ b/barney/volume/MCGrid.cu
@@ -3,6 +3,7 @@
 
 
 #include "barney/volume/MCGrid.h"
+#include "barney/volume/Volume.h"
 #include "rtcore/ComputeInterface.h"
 
 namespace BARNEY_NS {
@@ -93,25 +94,58 @@ namespace BARNEY_NS {
   __rtc_global
   void mapMCs(const rtc::ComputeInterface &ci,
               MajorantsGrid::DD grid,
-              TransferFunction::DD xf)
+              TransferFunction::DD xf
+#if BARNEY_USE_MULTI_SCATTERING
+              , PrincipledVolumeParams::DD principled
+#endif
+              )
   {
     int ix = ci.getThreadIdx().x
       +ci.getBlockIdx().x*ci.getBlockDim().x;
     if (ix >= grid.dims.x*grid.dims.y*grid.dims.z) return;
     range1f scalarRange = grid.scalarRanges[ix];
+#if BARNEY_USE_MULTI_SCATTERING
+    const float tfMaj = xf.majorant(scalarRange);
+    const float maj = principled.enabled
+      ? principledMajorant(scalarRange, principled) * tfMaj
+      : tfMaj;
+#else
     const float maj = xf.majorant(scalarRange);
+#endif
     grid.majorants[ix] = maj;
   }
   
-  /*! recompute all macro cells' majorant value by remap each such
-    cell's value range through the given transfer function */
+#if BARNEY_USE_MULTI_SCATTERING
+  void MajorantsGrid::computeMajorants(Volume *volume)
+  {
+    if (dims != mcGrid->dims)
+      resize(mcGrid->dims); 
+    assert(volume);
+    auto dims = mcGrid->dims;
+    assert(dims.x > 0);
+    assert(dims.y > 0);
+    assert(dims.z > 0);
+    size_t numCells = owl::common::volume(dims);
+    const int bs = 1024;
+    const int nb = (int)dru(numCells,bs);
+    for (auto device : *devices) 
+      device->sync();
+    
+    for (auto device : *devices) {
+      auto d_xf = volume->xf.getDD(device);
+      auto d_principled = volume->principled.getDD(device);
+      auto dd = getDD(device);
+      __rtc_launch(device->rtc,
+                   mapMCs,
+                   nb,bs,
+                   dd,d_xf,d_principled);
+    }
+    for (auto device : *devices) 
+      device->sync();
+  }
+#else
   void MajorantsGrid::computeMajorants(TransferFunction *xf)
   {
-// #ifndef NDEBUG
-//     std::cout << "-------------------------" << std::endl;
-//     std::cout << "(re-)computing majorants!" << std::endl;
-//     std::cout << "-------------------------" << std::endl;
-// #endif
     if (dims != mcGrid->dims)
       resize(mcGrid->dims); 
     assert(xf);
@@ -121,8 +155,6 @@ namespace BARNEY_NS {
     assert(dims.z > 0);
     size_t numCells = owl::common::volume(dims);
     const int bs = 1024;
-    // cuda num blocks
-    // const int nb = (int)divRoundUp((size_t)numCells,(size_t)bs);
     const int nb = (int)dru(numCells,bs);
     for (auto device : *devices) 
       device->sync();
@@ -138,6 +170,7 @@ namespace BARNEY_NS {
     for (auto device : *devices) 
       device->sync();
   }
+#endif
   
   /*! allocate memory for the given grid */
   void MajorantsGrid::resize(vec3i dims)

--- a/barney/volume/MCGrid.h
+++ b/barney/volume/MCGrid.h
@@ -6,12 +6,18 @@
 
 #include "barney/DeviceGroup.h"
 #include "barney/volume/TransferFunction.h"
+#include "barney/barneyConfig.h"
 #include "barney/common/math.h"
+#if BARNEY_USE_MULTI_SCATTERING
+#include "barney/volume/PrincipledVolume.h"
+#endif
 #if RTC_DEVICE_CODE
 # include "rtcore/ComputeInterface.h"
 #endif
 
 namespace BARNEY_NS {
+
+  struct Volume;
 
   /*! a grid of macro-cells, with each macro-cell storing both value
       range of the underlying field, and majorant after mapping
@@ -133,7 +139,11 @@ namespace BARNEY_NS {
 
     /*! given the current per-cell scalar ranges, map each such cell's
         range through the transfer functoin to compute a majorant */
+#if BARNEY_USE_MULTI_SCATTERING
+    void computeMajorants(Volume *volume);
+#else
     void computeMajorants(TransferFunction *xf);
+#endif
 
     /*! allocate memory for the given grid */
     void resize(vec3i dims);

--- a/barney/volume/PrincipledVolume.h
+++ b/barney/volume/PrincipledVolume.h
@@ -1,0 +1,161 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "barney/common/barney-common.h"
+
+namespace BARNEY_NS {
+
+  struct Device;
+
+  /*! Cycles-style principled volume coefficients evaluated directly from
+      scalar field samples (phase 2 — not baked through a 1D TF). */
+  struct PrincipledVolumeParams {
+    int     enabled = 0;
+    float   density = 1.f;
+    vec3f   scatterColor = vec3f(0.8f);
+    vec3f   absorptionColor = vec3f(0.f);
+    vec3f   emissionColor = vec3f(1.f);
+    float   densityThreshold = 0.f;
+    float   densityScale = 1.f;
+    range1f valueRange = { 0.f, 1.f };
+    float   emissionStrength = 0.f;
+    float   blackbodyIntensity = 0.f;
+    vec3f   blackbodyTint = vec3f(1.f);
+    float   temperature = 0.f;
+
+    struct DD {
+      int     enabled;
+      float   density;
+      vec3f   scatterColor;
+      vec3f   absorptionColor;
+      vec3f   emissionColor;
+      float   densityThreshold;
+      float   densityScale;
+      range1f valueRange;
+      float   emissionStrength;
+      float   blackbodyIntensity;
+      vec3f   blackbodyTint;
+      float   temperature;
+    };
+
+    inline DD getDD(Device *device) const
+    {
+      DD dd;
+      dd.enabled = enabled;
+      dd.density = density;
+      dd.scatterColor = scatterColor;
+      dd.absorptionColor = absorptionColor;
+      dd.emissionColor = emissionColor;
+      dd.densityThreshold = densityThreshold;
+      dd.densityScale = densityScale;
+      dd.valueRange = valueRange;
+      dd.emissionStrength = emissionStrength;
+      dd.blackbodyIntensity = blackbodyIntensity;
+      dd.blackbodyTint = blackbodyTint;
+      dd.temperature = temperature;
+      (void)device;
+      return dd;
+    }
+  };
+
+  inline __rtc_device
+  vec3f principledBlackbodyColor(float kelvin)
+  {
+    kelvin = clamp(kelvin, 1000.f, 40000.f);
+    float t = kelvin / 100.f;
+    float r, g, b;
+    if (t <= 66.f) {
+      r = 1.f;
+      g = clamp(0.390081578f * logf(t) - 0.631841444f, 0.f, 1.f);
+    } else {
+      r = clamp(1.292936186f * powf(t - 60.f, -0.1332047592f), 0.f, 1.f);
+      g = clamp(1.129890860f * powf(t - 60.f, -0.0755148492f), 0.f, 1.f);
+    }
+    if (t >= 66.f)
+      b = 1.f;
+    else if (t <= 19.f)
+      b = 0.f;
+    else
+      b = clamp(0.543206789f * logf(t - 10.f) - 1.196254089f, 0.f, 1.f);
+    return vec3f(r, g, b);
+  }
+
+  inline __rtc_device
+  float principledDensityFactor(float scalar,
+                                const PrincipledVolumeParams::DD &p)
+  {
+    float s = clamp(scalar, p.valueRange.lower, p.valueRange.upper);
+    if (p.densityThreshold > 0.f && s < p.densityThreshold)
+      return 0.f;
+    return p.density * max(s, 0.f) * p.densityScale;
+  }
+
+  inline __rtc_device
+  vec3f principledSigmaS(float scalar,
+                          const PrincipledVolumeParams::DD &p)
+  {
+    return principledDensityFactor(scalar, p) * p.scatterColor;
+  }
+
+  inline __rtc_device
+  vec3f principledSigmaA(float scalar,
+                          const PrincipledVolumeParams::DD &p)
+  {
+    return principledDensityFactor(scalar, p) * p.absorptionColor;
+  }
+
+  inline __rtc_device
+  float principledSigmaT(float scalar,
+                           const PrincipledVolumeParams::DD &p)
+  {
+    vec3f sigma_t = principledSigmaS(scalar, p) + principledSigmaA(scalar, p);
+    return reduce_max(sigma_t);
+  }
+
+  inline __rtc_device
+  vec4f principledSampleMap(float scalar,
+                            const PrincipledVolumeParams::DD &p)
+  {
+    vec3f sigma_s = principledSigmaS(scalar, p);
+    vec3f sigma_a = principledSigmaA(scalar, p);
+    vec3f sigma_t = sigma_s + sigma_a;
+    float sigma_t_scalar = reduce_max(sigma_t);
+    vec3f tint = vec3f(1.f);
+    if (sigma_t_scalar > 0.f) {
+      float ms = reduce_max(sigma_s);
+      tint = ms > 0.f ? sigma_s / ms : vec3f(1.f);
+    }
+    return vec4f(tint, sigma_t_scalar);
+  }
+
+  inline __rtc_device
+  vec3f principledEmission(float scalar,
+                           const PrincipledVolumeParams::DD &p)
+  {
+    float d = principledDensityFactor(scalar, p);
+    vec3f Le = p.emissionStrength * p.emissionColor * d;
+    if (p.blackbodyIntensity > 0.f && p.temperature > 0.f)
+      Le += p.blackbodyIntensity * p.blackbodyTint
+        * principledBlackbodyColor(p.temperature) * d;
+    return Le;
+  }
+
+  inline __rtc_device
+  float principledMajorant(range1f r,
+                           const PrincipledVolumeParams::DD &p)
+  {
+    if (r.lower > r.upper)
+      return 0.f;
+    float m = 0.f;
+    const int steps = 8;
+    for (int i = 0; i <= steps; ++i) {
+      float t = float(i) / float(steps);
+      float s = r.lower + t * r.span();
+      m = max(m, principledSigmaT(s, p));
+    }
+    return m;
+  }
+
+}

--- a/barney/volume/Volume.cpp
+++ b/barney/volume/Volume.cpp
@@ -3,13 +3,136 @@
 
 
 #include "barney/volume/Volume.h"
-#include "barney/volume/ScalarField.h"
 #include "barney/ModelSlot.h"
+#include "barney/barneyConfig.h"
+#if BARNEY_USE_MULTI_SCATTERING
+#include "barney/common/math.h"
+#else
+#include "barney/volume/ScalarField.h"
+#endif
 
 namespace BARNEY_NS {
 
   Volume::PLD *Volume::getPLD(Device *device)
   { return &perLogical[device->contextRank()]; }
+
+#if BARNEY_USE_MULTI_SCATTERING
+
+  void Volume::setXF(const range1f &domain,
+                     const bn_float4 *_values,
+                     int numValues,
+                     float baseDensity) 
+  {
+    std::vector<vec4f> values(numValues);
+    memcpy(values.data(),_values,numValues*sizeof(*_values));
+    xf.set(domain,values,baseDensity);
+    needsMajorantRebuild = true;
+  }
+
+  void Volume::commit()
+  {
+    if (!accel)
+      return;
+    if (needsMajorantRebuild && sf->mcGrid && sf->mcGrid->built()) {
+      accel->rebuildMajorantsOnly();
+      needsMajorantRebuild = false;
+    }
+    accel->refreshDeviceData();
+  }
+
+  bool Volume::set1i(const std::string &member,
+                     const int   &value) 
+  {
+    if (member == "userID") {
+      userID = value;
+      return true; 
+    }
+    if (member == "principledVolume") {
+      principled.enabled = value ? 1 : 0;
+      needsMajorantRebuild = true;
+      return true;
+    }
+    
+    return false;
+  }
+
+  bool Volume::set1f(const std::string &member,
+                     const float &value) 
+  {
+    if (member == "anisotropy") {
+      anisotropy = clamp(value, -0.99f, 0.99f);
+      return true;
+    }
+    if (member == "scatteringAlbedo") {
+      scatteringAlbedo = clamp(value, 0.f, 1.f);
+      return true;
+    }
+    if (member == "principledDensity") {
+      principled.density = value;
+      needsMajorantRebuild = true;
+      return true;
+    }
+    if (member == "principledDensityThreshold") {
+      principled.densityThreshold = max(value, 0.f);
+      needsMajorantRebuild = true;
+      return true;
+    }
+    if (member == "principledDensityScale") {
+      principled.densityScale = value > 0.f ? value : 1.f;
+      needsMajorantRebuild = true;
+      return true;
+    }
+    if (member == "principledEmissionStrength") {
+      principled.emissionStrength = max(value, 0.f);
+      return true;
+    }
+    if (member == "principledBlackbodyIntensity") {
+      principled.blackbodyIntensity = max(value, 0.f);
+      return true;
+    }
+    if (member == "principledTemperature") {
+      principled.temperature = max(value, 0.f);
+      return true;
+    }
+    return false;
+  }
+
+  bool Volume::set2f(const std::string &member,
+                     const vec2f &value)
+  {
+    if (member == "principledValueRange") {
+      principled.valueRange = range1f(value.x, value.y);
+      needsMajorantRebuild = true;
+      return true;
+    }
+    return false;
+  }
+
+  bool Volume::set3f(const std::string &member,
+                     const vec3f &value)
+  {
+    if (member == "principledScatterColor") {
+      principled.scatterColor = max(value, vec3f(0.f));
+      needsMajorantRebuild = true;
+      return true;
+    }
+    if (member == "principledAbsorptionColor") {
+      principled.absorptionColor = max(value, vec3f(0.f));
+      needsMajorantRebuild = true;
+      return true;
+    }
+    if (member == "principledEmissionColor") {
+      principled.emissionColor = max(value, vec3f(0.f));
+      return true;
+    }
+    if (member == "principledBlackbodyTint") {
+      principled.blackbodyTint = max(value, vec3f(0.f));
+      return true;
+    }
+    return false;
+  }
+
+#else
 
   void Volume::setXF(const range1f &domain,
                      const bn_float4 *_values,
@@ -31,6 +154,8 @@ namespace BARNEY_NS {
     
     return false;
   }
+
+#endif
   
   inline ScalarField::SP assertNotNull(const ScalarField::SP &s)
   { assert(s); return s; }
@@ -50,12 +175,13 @@ namespace BARNEY_NS {
 
   const TransferFunction *VolumeAccel::getXF() const { return &volume->xf; }
   
-  /*! (re-)build the accel structure for this volume, probably after
-    changes to transfer functoin (or later, scalar field) */
   void Volume::build(bool full_rebuild)
   {
     assert(accel);
     accel->build(full_rebuild);
+#if BARNEY_USE_MULTI_SCATTERING
+    needsMajorantRebuild = false;
+#endif
     for (auto device : *devices)
       device->sbtDirty = true;
   }

--- a/barney/volume/Volume.h
+++ b/barney/volume/Volume.h
@@ -8,6 +8,10 @@
 #include "barney/Object.h"
 #include "barney/volume/TransferFunction.h"
 #include "barney/volume/ScalarField.h"
+#include "barney/barneyConfig.h"
+#if BARNEY_USE_MULTI_SCATTERING
+#include "barney/volume/PrincipledVolume.h"
+#endif
 #include <array>
 
 namespace BARNEY_NS {
@@ -30,6 +34,11 @@ namespace BARNEY_NS {
     virtual ~VolumeAccel() = default;
 
     virtual void build(bool full_rebuild) = 0;
+
+#if BARNEY_USE_MULTI_SCATTERING
+    virtual void rebuildMajorantsOnly();
+    virtual void refreshDeviceData();
+#endif
 
     const TransferFunction *getXF() const;
     
@@ -58,14 +67,35 @@ namespace BARNEY_NS {
       {
         float f = sfSampler.sample(point,dbg);
         if (isnan(f)) return vec4f(0.f);
-        vec4f mapped = xf.map(f,dbg);
-        return mapped;
+#if BARNEY_USE_MULTI_SCATTERING
+        if (principled.enabled) {
+          vec4f tf = xf.map(f, dbg);
+          if (tf.w <= 0.f)
+            return vec4f(0.f);
+          vec4f p = principledSampleMap(f, principled);
+          return vec4f(getPos(p) * getPos(tf), p.w * tf.w);
+        }
+#endif
+        return xf.map(f,dbg);
       }
+
+#if BARNEY_USE_MULTI_SCATTERING
+      inline __rtc_device
+      float sampleScalar(vec3f point, bool dbg=false) const
+      {
+        return sfSampler.sample(point, dbg);
+      }
+#endif
       
-      ScalarField::DD        sfCommon;
-      typename SFSampler::DD sfSampler;
-      TransferFunction::DD   xf;
-      int                    userID;
+      ScalarField::DD               sfCommon;
+      typename SFSampler::DD      sfSampler;
+      TransferFunction::DD        xf;
+#if BARNEY_USE_MULTI_SCATTERING
+      PrincipledVolumeParams::DD    principled;
+      float                         anisotropy;
+      float                         scatteringAlbedo;
+#endif
+      int                           userID;
     };
     
     template<typename SFSampler>
@@ -76,6 +106,11 @@ namespace BARNEY_NS {
       dd.sfSampler = sampler->getDD(device);
       dd.xf = xf.getDD(device);
       dd.userID = userID;
+#if BARNEY_USE_MULTI_SCATTERING
+      dd.principled = principled.getDD(device);
+      dd.anisotropy = anisotropy;
+      dd.scatteringAlbedo = scatteringAlbedo;
+#endif
       return dd;
     }
 
@@ -100,12 +135,30 @@ namespace BARNEY_NS {
                const bn_float4 *values,
                int numValues,
                float baseDensity) override;
+#if BARNEY_USE_MULTI_SCATTERING
+    void commit() override;
     bool set1i(const std::string &member,
                const int   &value) override;
+    bool set1f(const std::string &member,
+               const float &value) override;
+    bool set2f(const std::string &member,
+               const vec2f &value) override;
+    bool set3f(const std::string &member,
+               const vec3f &value) override;
+#else
+    bool set1i(const std::string &member,
+               const int   &value) override;
+#endif
                
     ScalarField::SP  sf;
     VolumeAccel::SP  accel;
     TransferFunction xf;
+#if BARNEY_USE_MULTI_SCATTERING
+    PrincipledVolumeParams principled;
+    float anisotropy = 0.6f;
+    float scatteringAlbedo = 0.9f;
+    bool needsMajorantRebuild = false;
+#endif
     DevGroup::SP const devices;
     int userID = 0;
     
@@ -176,4 +229,10 @@ namespace BARNEY_NS {
     assert(volume);
     assert(volume->sf);
   }
+
+#if BARNEY_USE_MULTI_SCATTERING
+  inline void VolumeAccel::rebuildMajorantsOnly() {}
+
+  inline void VolumeAccel::refreshDeviceData() {}
+#endif
 }


### PR DESCRIPTION
This MR exposes  the `BARNEY_USE_MULTI_SCATTERING` compilation flag. This unlocks the code path for a new PrincipledVolume volume type that allows multiple scattering in place of the single scattering approach currently used. 